### PR TITLE
feature: upgrade default luarocks to 3.8.0 which converts git:// to https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For a more complete example see: https://github.com/leafo/gh-actions-lua/blob/ma
 
 ### `luarocksVersion`
 
-**Default**: `"3.5.0"`
+**Default**: `"3.8.0"`
 
 Specifies which version of LuaRocks to install. Must be listed on https://luarocks.github.io/luarocks/releases/
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   luaRocksVersion:
     description: "The version of LuaRocks to install, must be available on https://luarocks.github.io/luarocks/releases/"
     required: false
-    default: "3.5.0"
+    default: "3.8.0"
 
 runs:
   using: 'node12'


### PR DESCRIPTION
See https://github.com/luarocks/luarocks/commit/9ff512e35455939f02eaec2318e3acc77782fdeb