### PR TITLE
Update Node to version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
Github Action is shorting removing Node 16, as it is End of Life.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/