### PR TITLE
feat: allow use git commit id as version

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,18 +12,21 @@ const LUA_PREFIX = ".lua" // default location for existing Lua installation
 const LUAROCKS_PREFIX = ".luarocks" // default location for LuaRocks installation
 
 async function main() {
-  const luaRocksVersion = core.getInput('luaRocksVersion', { required: true })
-
-  const luaRocksExtractPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX, `luarocks-${luaRocksVersion}`)
-  const luaRocksInstallPath = path.join(process.cwd(), LUAROCKS_PREFIX)
+  let luaRocksVersion = core.getInput('luaRocksVersion', { required: true })
 
   let sourceTar
   if (luaRocksVersion.startsWith("@")) {
-    // download the specified github commit
-    sourceTar = await tc.downloadTool(`https://github.com/luarocks/luarocks/archive/${luaRocksVersion.substring(1)}.tar.gz`)
+    luaRocksVersion = luaRocksVersion.substring(1) // remove the '@' prefix
+    if (!luaRocksVersion) {
+      luaRocksVersion = "master" // default to master branch if no version is specified
+    }
+    sourceTar = await tc.downloadTool(`https://github.com/luarocks/luarocks/archive/${luaRocksVersion}.tar.gz`)
   } else {
     sourceTar = await tc.downloadTool(`https://luarocks.org/releases/luarocks-${luaRocksVersion}.tar.gz`)
   }
+
+  const luaRocksExtractPath = path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX, `luarocks-${luaRocksVersion}`)
+  const luaRocksInstallPath = path.join(process.cwd(), LUAROCKS_PREFIX)
 
   await io.mkdirP(luaRocksExtractPath)
   await tc.extractTar(sourceTar, path.join(process.env["RUNNER_TEMP"], BUILD_PREFIX))


### PR DESCRIPTION
Currently this action only supports downloading source packages from `luarocks.org` in semver format.
In some cases, we need to allow it to use code from a specific git commit. For example, https://github.com/luarocks/luarocks/pull/1799

So this PR adds the precedent that when the version number starts with @ (e.g., `@12345678`), the subsequent string `12345678` will be treated as the git commit ID, which will cause the action to download the tgz from the GitHub archive.
If the version number is `@`, it means to use master branching, which is an easy way to do it.
I adopted this pattern from [hererocks](https://github.com/luarocks/hererocks?tab=readme-ov-file#version-selection), I didn't create it.