### PR TITLE
Update latest version to 3.12.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   luaRocksVersion:
     description: "The version of LuaRocks to install, must be available on https://luarocks.github.io/luarocks/releases/"
     required: false
-    default: "3.11.1"
+    default: "3.12.2"
   withLuaPath:
     description: "Directly specify existing version of Lua to use (as ./configure --with-lua)"
     required: false


### PR DESCRIPTION
Fixes problems using luarocks on luajit, which has table size limitations hitting the current luarocks package size.

See https://github.com/luarocks/luarocks/issues/1797