### PR TITLE
doc: fix `luarocksVersion` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For a more complete example see: https://github.com/leafo/gh-actions-lua/blob/ma
 
 ## Inputs
 
-### `luarocksVersion`
+### `luaRocksVersion`
 
 **Default**: `"3.11.1"`
 
@@ -36,7 +36,7 @@ Example:
 ```yaml
 - uses: leafo/gh-actions-luarocks@v4
   with:
-    luarocksVersion: "3.1.3"
+    luaRocksVersion: "3.1.3"
 ```
 
 ### `withLuaPath`


### PR DESCRIPTION
Fixes a typo in the README where the `luarocksVersion` input had the wrong casing. Correct usage is spelled `luaRocksVersion`.